### PR TITLE
Link for the Wiki has been updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# If you land here, please note that this a fork for ZHD1987E, and changes reflected on the main repository may not reflect here.
+**If you land here, please note that this a fork for ZHD1987E, and changes reflected on the main repository may not reflect here.**
 
 # NUS CS2030 AY2023/24 Semester 2
 ![Java](https://img.shields.io/badge/java-%23ED8B00.svg?&style=for-the-badge&logo=java&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 Welcome to the home repository for CS2030! 😃
 
-To find out more about how to contribute, [click here!](https://github.com/nus-cs2030/2324-s1/wiki)
+To find out more about how to contribute, [click here!](https://github.com/nus-cs2030/2324-s2/wiki)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# If you land here, please note that this a fork for ZHD1987E, and changes reflected on the main repository may not reflect here.
+
 # NUS CS2030 AY2023/24 Semester 2
 ![Java](https://img.shields.io/badge/java-%23ED8B00.svg?&style=for-the-badge&logo=java&logoColor=white)
 ![Vim](https://img.shields.io/badge/VIM-%2311AB00.svg?style=for-the-badge&logo=vim&logoColor=white)


### PR DESCRIPTION
What happened was that the old wiki link no longer exists, so I have to redirect it to the current (as of 18 Jan. 2024) wiki page which deals with the next semester.